### PR TITLE
Fix git password uniqueness problem.

### DIFF
--- a/project-docs/release-notes/version-3.2.0.md
+++ b/project-docs/release-notes/version-3.2.0.md
@@ -56,3 +56,8 @@ Bugs Fixed
   sent in lower case. This is allowed by HTTP specification as meant to be case
   insensitive, but some web services were only accepting mixed case, so use the
   mixed case convention so better chance of working with broken web services.
+
+* Password for `git` application server was not unique per workshop session but
+  was the same for all workshop sessions within the workshop environment. The
+  `git` credentials therefore only differed based on `git` username, which was
+  predictable as was based on workshop session name.

--- a/session-manager/handlers/application_git.py
+++ b/session-manager/handlers/application_git.py
@@ -11,7 +11,7 @@ def git_workshop_spec_patches(workshop_spec, application_properties):
 
     git_host = f"git-$(session_name).{INGRESS_DOMAIN}"
     git_username = "$(session_name)"
-    git_password = "".join(random.sample(characters, 32))
+    git_password = "$(services_password)"
 
     git_auth_token = "$(base64($(git_username):$(git_password)))"
 


### PR DESCRIPTION
fixes #652 

For now this makes git password same as general purpose services password. Had them different before so not sharing services password intended for internal cluster usage, outside of cluster if someone needed to push to git from outside of workshop container. Likelihood of workshop needing that is low and so risk of it being an issue is very small.