### PR TITLE
Fixing resolution of images

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/cert-manager/overlays/overlay-modify-acmeresolver-reference.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/cert-manager/overlays/overlay-modify-acmeresolver-reference.yaml
@@ -1,0 +1,50 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:yaml", "yaml")
+
+#@ def addImageAnnotation(l,image):
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    acmesolver-image: #@ image
+#@ end
+
+#@ def moveImageName(l,r):
+#@   image = "notfound"
+#@   if "spec" in l and "template" in l["spec"] and "spec" in l["spec"]["template"] and "containers" in l["spec"]["template"]["spec"]:
+#@     for container in l["spec"]["template"]["spec"]["containers"]:
+#@       if container["name"] == "cert-manager-controller":
+#@         for arg in container["args"]:
+#@           if arg.startswith("--acme-http01-solver-image="):
+#@             image = arg.split("=")[1]
+#@             break
+#@           end
+#@         end
+#@       end
+#@     end
+#@   end
+#@   return overlay.apply(l, addImageAnnotation(l,image))
+#@ end
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "cert-manager"}})
+#@overlay/replace via=lambda l,r: moveImageName(l,r)
+---
+
+#! This third  overlay will replace the arg in the container
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "cert-manager"}})
+---
+spec:
+  template:
+    spec:
+      containers:
+        #@overlay/match by="name"
+        - name: cert-manager-controller
+          args:
+            #@overlay/match by=lambda i,l,r: l.startswith("--acme-http01-solver-image=")
+            -  #@ "--acme-http01-solver-image=$(ACMESOLVER_IMAGE)"
+          env:
+            - name: ACMESOLVER_IMAGE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['acmesolver-image']

--- a/carvel-packages/installer/bundle/kbld/kbld-bundle.yaml
+++ b/carvel-packages/installer/bundle/kbld/kbld-bundle.yaml
@@ -4,24 +4,19 @@ minimumRequiredVersion: 0.30.0
 kind: Config
 searchRules:
   - keyMatcher:
-      name: SESSION_MANAGER_IMAGE
+      name: config.yaml
+    updateStrategy:
+      yaml:
+        searchRules:
+        - keyMatcher:
+            name: image
   - keyMatcher:
-      name: SECRETS_MANAGER_IMAGE
+      name: values.yaml
+    updateStrategy:
+      yaml:
+        searchRules:
+        - keyMatcher:
+            name: image
+  # This rule replaces acmeresolver image in cert-manager deployment (after upstream descriptor has been modified by educates installer)
   - keyMatcher:
-      name: TUNNEL_MANAGER_IMAGE
-  - keyMatcher:
-      name: TRAINING_PORTAL_IMAGE
-  - keyMatcher:
-      name: DOCKER_IN_DOCKER_IMAGE
-  - keyMatcher:
-      name: DOCKER_REGISTRY_IMAGE
-  - keyMatcher:
-      name: PAUSE_CONTAINER_IMAGE
-  - keyMatcher:
-      name: BASE_ENVIRONMENT_IMAGE
-  - keyMatcher:
-      name: JDK8_ENVIRONMENT_IMAGE
-  - keyMatcher:
-      name: JDK11_ENVIRONMENT_IMAGE
-  - keyMatcher:
-      name: CONDA_ENVIRONMENT_IMAGE
+      name: acmesolver-image

--- a/carvel-packages/installer/scenarios/custom/test-custom-scenario-4/description.md
+++ b/carvel-packages/installer/scenarios/custom/test-custom-scenario-4/description.md
@@ -1,0 +1,5 @@
+kind using provided domain with custom configuration
+In this scenario we don't use any global educates config, but the one in the clusterPackages.
+We do not provide config for `kapp-controller` and `certs` so these packages will be `disabled` in
+generated config. All the other `clusterPackages` configuration will be respected.
+We also provide imageVersions configuration that should be kept.

--- a/carvel-packages/installer/scenarios/custom/test-custom-scenario-4/expected.yaml
+++ b/carvel-packages/installer/scenarios/custom/test-custom-scenario-4/expected.yaml
@@ -1,0 +1,77 @@
+clusterPackages:
+  contour:
+    enabled: true
+    settings:
+      infraProvider: custom
+      contour:
+        replicas: 10
+  cert-manager:
+    enabled: true
+    settings:
+      serviceaccount:
+        annotations:
+          cert-manager.custom: "true"
+  external-dns:
+    enabled: false
+    settings: {}
+  certs:
+    enabled: false
+    settings: {}
+  kyverno:
+    enabled: true
+    settings: {}
+  kapp-controller:
+    enabled: false
+    settings: {}
+  educates:
+    enabled: true
+    settings:
+      clusterIngress:
+        domain: educates.example.com
+      imageVersions:
+        - image: ghcr.io/educates/educates-session-manager:3.1.0
+          name: session-manager
+        - image: ghcr.io/educates/educates-training-portal:3.1.0
+          name: training-portal
+        - image: ghcr.io/educates/educates-docker-registry:3.1.0
+          name: docker-registry
+        - image: ghcr.io/educates/educates-pause-container:3.1.0
+          name: pause-container
+        - image: ghcr.io/educates/educates-base-environment:3.1.0
+          name: base-environment
+        - image: ghcr.io/educates/educates-jdk8-environment:3.1.0
+          name: jdk8-environment
+        - image: ghcr.io/educates/educates-jdk11-environment:3.1.0
+          name: jdk11-environment
+        - image: ghcr.io/educates/educates-jdk17-environment:3.1.0
+          name: jdk17-environment
+        - image: ghcr.io/educates/educates-jdk21-environment:3.1.0
+          name: jdk21-environment
+        - image: ghcr.io/educates/educates-conda-environment:3.1.0
+          name: conda-environment
+        - image: ghcr.io/educates/educates-secrets-manager:3.1.0
+          name: secrets-manager
+        - image: ghcr.io/educates/educates-tunnel-manager:3.1.0
+          name: tunnel-manager
+        - image: ghcr.io/educates/educates-image-cache:3.1.0
+          name: image-cache
+        - image: ghcr.io/educates/educates-assets-server:3.1.0
+          name: assets-server
+        - image: ghcr.io/educates/educates-lookup-service:3.1.0
+          name: lookup-service
+        - image: debian:sid-20230502-slim
+          name: debian-base-image
+        - image: docker:20.10.18-dind
+          name: docker-in-docker
+        - image: rancher/k3s:v1.27.14-k3s1
+          name: rancher-k3s-v1.27
+        - image: rancher/k3s:v1.28.10-k3s1
+          name: rancher-k3s-v1.28
+        - image: rancher/k3s:v1.29.5-k3s1
+          name: rancher-k3s-v1.29
+        - image: rancher/k3s:v1.30.1-k3s1
+          name: rancher-k3s-v1.30
+        - image: loftsh/vcluster:0.18.1
+          name: loftsh-vcluster
+      sessionCookies:
+        domain: educates.example.com

--- a/carvel-packages/installer/scenarios/custom/test-custom-scenario-4/values.yaml
+++ b/carvel-packages/installer/scenarios/custom/test-custom-scenario-4/values.yaml
@@ -1,0 +1,77 @@
+clusterPackages:
+  contour:
+    enabled: true
+    settings: 
+      infraProvider: custom
+      contour:
+        replicas: 10
+  cert-manager:
+    enabled: true
+    settings:
+      serviceaccount:
+        annotations:
+          cert-manager.custom: "true"
+  external-dns:
+    enabled: false
+    settings:
+      infraProvider: gcp
+      gcp:
+        args:
+          project: "PROJECT_ID"
+  kyverno:
+    enabled: true
+    settings: {}
+  educates:
+    enabled: true
+    settings:
+      clusterIngress:
+        domain: "educates.example.com"
+      sessionCookies:
+        domain: "educates.example.com"
+clusterInfrastructure:
+  provider: "custom"
+imageVersions:
+- name: session-manager
+  image: ghcr.io/educates/educates-session-manager:3.1.0
+- name: training-portal
+  image: ghcr.io/educates/educates-training-portal:3.1.0
+- name: docker-registry
+  image: ghcr.io/educates/educates-docker-registry:3.1.0
+- name: pause-container
+  image: ghcr.io/educates/educates-pause-container:3.1.0
+- name: base-environment
+  image: ghcr.io/educates/educates-base-environment:3.1.0
+- name: jdk8-environment
+  image: ghcr.io/educates/educates-jdk8-environment:3.1.0
+- name: jdk11-environment
+  image: ghcr.io/educates/educates-jdk11-environment:3.1.0
+- name: jdk17-environment
+  image: ghcr.io/educates/educates-jdk17-environment:3.1.0
+- name: jdk21-environment
+  image: ghcr.io/educates/educates-jdk21-environment:3.1.0
+- name: conda-environment
+  image: ghcr.io/educates/educates-conda-environment:3.1.0
+- name: secrets-manager
+  image: ghcr.io/educates/educates-secrets-manager:3.1.0
+- name: tunnel-manager
+  image: ghcr.io/educates/educates-tunnel-manager:3.1.0
+- name: image-cache
+  image: ghcr.io/educates/educates-image-cache:3.1.0
+- name: assets-server
+  image: ghcr.io/educates/educates-assets-server:3.1.0
+- name: lookup-service
+  image: ghcr.io/educates/educates-lookup-service:3.1.0
+- name: debian-base-image
+  image: debian:sid-20230502-slim
+- name: docker-in-docker
+  image: docker:20.10.18-dind # 27.5.1-dind
+- name: rancher-k3s-v1.27
+  image: rancher/k3s:v1.27.14-k3s1
+- name: rancher-k3s-v1.28
+  image: rancher/k3s:v1.28.10-k3s1
+- name: rancher-k3s-v1.29
+  image: rancher/k3s:v1.29.5-k3s1
+- name: rancher-k3s-v1.30
+  image: rancher/k3s:v1.30.1-k3s1
+- name: loftsh-vcluster
+  image: loftsh/vcluster:0.18.1

--- a/project-docs/release-notes/version-3.2.1.md
+++ b/project-docs/release-notes/version-3.2.1.md
@@ -5,3 +5,19 @@ New Features
 ------------
 
 * Added `uv`, a Python package and project manager, to the workshop base image.
+
+
+Features Changed
+----------------
+
+* Updated `go` version for the CLI to 1.23.7 and other dependencies such as 
+  kind, that now creates a Kubernetes 1.32.2 cluster. Minimal Docker Desktop 
+  version that can be used has also been bumped to 4.34 released by end of 
+  August 2024.
+
+Bugs Fixed
+----------
+
+* Fixed generation of resolved images via kbld, so that descriptors and 
+  configuration now has the sha256 resolved version of the images. This fixes
+  the ability to create disconnected installs.


### PR DESCRIPTION
This fixes the ability to run disconnected installs as now the configuration and descriptors can have the resolved sha256 of every image referenced.

Fixes #605 