### PR TITLE
Fixing problem generated by previous kbld fix

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/config/save-config-overlay.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/config/save-config-overlay.yaml
@@ -18,5 +18,5 @@ metadata:
   name: educates-config
   namespace: educates
 data:
-  config.yaml: #@ yaml.encode(removeNulls(data.values.config))
-  values.yaml: #@ yaml.encode(data.values.values)
+  educates-original-config.yaml: #@ yaml.encode(removeNulls(data.values.config))
+  educates-processed-values.yaml: #@ yaml.encode(data.values.values)

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/06-secrets.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/06-secrets.yaml
@@ -15,9 +15,10 @@ metadata:
   annotations:
     kapp.k14s.io/versioned: ""
     kapp.k14s.io/num-versions: "5"
-data:
-  values.yaml: #@ base64.encode(yaml.encode(data.values))
-  kyverno-policies.yaml: #@ base64.encode(yaml.encode(kyverno_policies))
+    kapp.k14s.io/disable-original: ""
+stringData:
+  educates-operator-config.yaml: #@ yaml.encode(data.values)
+  kyverno-policies.yaml: #@ yaml.encode(kyverno_policies)
 
 #@ ingress_certificate = getattr(data.values.clusterIngress.tlsCertificate, "tls.crt")
 #@ ingress_private_key = getattr(data.values.clusterIngress.tlsCertificate, "tls.key")

--- a/carvel-packages/installer/bundle/kbld/kbld-bundle.yaml
+++ b/carvel-packages/installer/bundle/kbld/kbld-bundle.yaml
@@ -3,15 +3,22 @@ apiVersion: kbld.k14s.io/v1alpha1
 minimumRequiredVersion: 0.30.0
 kind: Config
 searchRules:
+  # - keyMatcher:
+  #     name: educates-original-config.yaml
+  #   updateStrategy:
+  #     yaml:
+  #       searchRules:
+  #       - keyMatcher:
+  #           name: image
   - keyMatcher:
-      name: config.yaml
+      name: educates-processed-values.yaml
     updateStrategy:
       yaml:
         searchRules:
         - keyMatcher:
             name: image
   - keyMatcher:
-      name: values.yaml
+      name: educates-operator-config.yaml
     updateStrategy:
       yaml:
         searchRules:

--- a/client-programs/pkg/cmd/admin_platform_config_cmd.go
+++ b/client-programs/pkg/cmd/admin_platform_config_cmd.go
@@ -21,28 +21,27 @@ var (
   educates admin platform config --from-cluster 
   educates admin platform config --from-cluster --kubeconfig /path/to/kubeconfig --context my-cluster
 
-  # Get configuration config using locally built educates package (version latest does the same and skips image resolution)
-  educates admin platform config --config config.yaml  --package-repository localhost:5001 --version 0.0.1
-  educates admin platform config --config config.yaml  --version latest
-
   # Get configuration config with different domain (to make copies of the config)
   educates admin platform config --local-config --domain cluster1.dev.educates.io > cluster1-config.yaml
-  educates admin platform config --config config.yaml --domain cluster2.dev.educates.io > cluster2-config.yaml
   `
 )
 
 type PlatformConfigOptions struct {
 	KubeconfigOptions
-	Domain            string
-	Version           string
-	PackageRepository string
-	LocalConfig       bool
-	FromCluster       bool
-	Verbose           bool
+	Domain      string
+	LocalConfig bool
+	FromCluster bool
+	Verbose     bool
 }
 
 func (o *PlatformConfigOptions) Run() error {
 	installer := installer.NewInstaller()
+
+	// Validation: Check if domain is set when from-cluster is true
+	// TODO: Maybe be able to modify the domain for the from-cluster config as well?
+	if o.FromCluster && o.Domain != "" {
+		return fmt.Errorf("domain must not be set when from-cluster is true")
+	}
 
 	if o.FromCluster {
 		config, err := installer.GetConfigFromCluster(o.Kubeconfig, o.Context)
@@ -100,23 +99,11 @@ func (p *ProjectInfo) NewAdminPlatformConfigCmd() *cobra.Command {
 		false,
 		"print verbose output",
 	)
-	c.Flags().StringVar(
-		&o.PackageRepository,
-		"package-repository",
-		p.ImageRepository,
-		"image repository hosting package bundles",
-	)
-	c.Flags().StringVar(
-		&o.Version,
-		"version",
-		p.Version,
-		"version to be installed",
-	)
 	c.Flags().BoolVar(
 		&o.LocalConfig,
 		"local-config",
 		false,
-		"Use local configuration. When used, --config and --domain flags are ignored",
+		"Use local configuration",
 	)
 	// TODO: From cluster
 	c.Flags().BoolVar(

--- a/client-programs/pkg/installer/installer.go
+++ b/client-programs/pkg/installer/installer.go
@@ -36,6 +36,8 @@ const EducatesInstallerString = "educates-installer"
 const EducatesInstallerAppString = "label:installer=educates-installer.app"
 const educatesConfigNamespace = "educates"
 const educatesConfigConfigMapName = "educates-config"
+const processedValuesKey = "educates-processed-values.yaml"
+const originalConfigKey = "educates-original-config.yaml"
 
 // We use a NullWriter to suppress the output of some commands, like kbld
 type NullWriter int
@@ -185,7 +187,7 @@ func (inst *Installer) GetValuesFromCluster(kubeconfig string, kubeContext strin
 		return "", errors.Wrap(err, "error querying the cluster")
 	}
 
-	valuesData, ok := values.Data["values.yaml"]
+	valuesData, ok := values.Data[processedValuesKey]
 
 	if !ok {
 		return "", errors.New("no platform configuration found")
@@ -211,7 +213,7 @@ func (inst *Installer) GetConfigFromCluster(kubeconfig string, kubeContext strin
 		return "", errors.Wrap(err, "error querying the cluster")
 	}
 
-	valuesData, ok := values.Data["config.yaml"]
+	valuesData, ok := values.Data[originalConfigKey]
 
 	if !ok {
 		return "", errors.New("no platform configuration found")

--- a/secrets-manager/handlers/operator_config.py
+++ b/secrets-manager/handlers/operator_config.py
@@ -8,14 +8,8 @@ logger = logging.getLogger("educates")
 
 config_values = {}
 
-if os.path.exists("/opt/app-root/config/values.yaml"):
-    with open("/opt/app-root/config/values.yaml") as fp:
-        config_values = yaml.load(fp, Loader=yaml.Loader)
-
-config_values = {}
-
-if os.path.exists("/opt/app-root/config/values.yaml"):
-    with open("/opt/app-root/config/values.yaml") as fp:
+if os.path.exists("/opt/app-root/config/educates-operator-config.yaml"):
+    with open("/opt/app-root/config/educates-operator-config.yaml") as fp:
         config_values = yaml.load(fp, Loader=yaml.Loader)
 
 OPERATOR_NAMESPACE = lookup(config_values, "operator.namespace", "educates")

--- a/session-manager/handlers/operator_config.py
+++ b/session-manager/handlers/operator_config.py
@@ -11,8 +11,8 @@ logger = logging.getLogger("educates")
 
 config_values = {}
 
-if os.path.exists("/opt/app-root/config/values.yaml"):
-    with open("/opt/app-root/config/values.yaml") as fp:
+if os.path.exists("/opt/app-root/config/educates-operator-config.yaml"):
+    with open("/opt/app-root/config/educates-operator-config.yaml") as fp:
         config_values = yaml.load(fp, Loader=yaml.Loader)
 
 PLATFORM_ARCH = os.environ.get("PLATFORM_ARCH", "")


### PR DESCRIPTION
Modified:
- Name of key in educates-config secret to `educates-operator-config.yaml` and provided as stringData
- Name of keys in educates-config configmap to `educates-original-config.yaml` and `educates-processed-values.yaml`
- CLI to use these new names for `educates admin platform values --from-cluster` and `educates admin platform config --from-cluster`
- Operator (secret-manager and session-manager) to use new key in educates-config secret
- kbld searchRules
- Removed unused code in `admin_platform_config_cmd.go`

This PR fixes a problem introduced in #672 which finally solves #605