### PR TITLE
Local resolver reload

### DIFF
--- a/client-programs/pkg/cmd/local_resolver_cmd_group.go
+++ b/client-programs/pkg/cmd/local_resolver_cmd_group.go
@@ -21,6 +21,7 @@ func (p *ProjectInfo) NewLocalResolverCmdGroup() *cobra.Command {
 			Commands: []*cobra.Command{
 				p.NewLocalResolverDeployCmd(),
 				p.NewLocalResolverDeleteCmd(),
+				p.NewLocalResolverUpdateCmd(),
 			},
 		},
 	}

--- a/client-programs/pkg/cmd/local_resolver_update_cmd.go
+++ b/client-programs/pkg/cmd/local_resolver_update_cmd.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/educates/educates-training-platform/client-programs/pkg/config"
+	"github.com/educates/educates-training-platform/client-programs/pkg/resolver"
+)
+
+type LocalResolverUpdateOptions struct {
+	Config string
+	Domain string
+}
+
+func (o *LocalResolverUpdateOptions) Run() error {
+	var fullConfig *config.InstallationConfig
+	var err error = nil
+
+	if o.Config != "" {
+		fullConfig, err = config.NewInstallationConfigFromFile(o.Config)
+	} else {
+		fullConfig, err = config.NewInstallationConfigFromUserFile()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return resolver.UpdateResolver(fullConfig.ClusterIngress.Domain, fullConfig.LocalDNSResolver.TargetAddress, fullConfig.LocalDNSResolver.ExtraDomains)
+}
+
+func (p *ProjectInfo) NewLocalResolverUpdateCmd() *cobra.Command {
+	var o LocalResolverUpdateOptions
+
+	var c = &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "update",
+		Short: "Updates the local DNS resolver",
+		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+	}
+
+	c.Flags().StringVar(
+		&o.Config,
+		"config",
+		"",
+		"path to the installation config file for Educates",
+	)
+
+	return c
+}

--- a/client-programs/pkg/resolver/resolver.go
+++ b/client-programs/pkg/resolver/resolver.go
@@ -214,6 +214,15 @@ func generateDnsmasqConfig(domain string, targetAddress string, extraDomains []s
 		ExtraDomains  []string
 	}
 
+	// We remove from extraDomains any domains that are already included in the
+	// IngressDomain.
+
+	for i, extraDomain := range extraDomains {
+		if domain == extraDomain {
+			extraDomains = append(extraDomains[:i], extraDomains[i+1:]...)
+		}
+	}
+
 	config := TemplateConfig{
 		IngressDomain: domain,
 		TargetAddress: targetAddress,

--- a/client-programs/pkg/resolver/resolver.go
+++ b/client-programs/pkg/resolver/resolver.go
@@ -67,55 +67,9 @@ func DeployResolver(domain string, targetAddress string, extraDomains []string) 
 	defer reader.Close()
 	io.Copy(os.Stdout, reader)
 
-	dnsmasqConfigTemplate, err := template.New("dnsmasq-config").Parse(dnsmasqConfigTemplateData)
-
+	configFileName, err := generateDnsmasqConfig(domain, targetAddress, extraDomains)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse dnsmasq config template")
-	}
-
-	var clusterConfigData bytes.Buffer
-
-	localIPAddress, err := config.HostIP()
-
-	if err != nil {
-		localIPAddress = "127.0.0.1"
-	}
-
-	if targetAddress == "" {
-		targetAddress = localIPAddress
-	}
-
-	type TemplateConfig struct {
-		IngressDomain string
-		TargetAddress string
-		ExtraDomains  []string
-	}
-
-	config := TemplateConfig{
-		IngressDomain: domain,
-		TargetAddress: targetAddress,
-		ExtraDomains:  extraDomains,
-	}
-
-	err = dnsmasqConfigTemplate.Execute(&clusterConfigData, config)
-
-	if err != nil {
-		return errors.Wrap(err, "failed to generate dnsmasq config")
-	}
-
-	configFileDir := utils.GetEducatesHomeDir()
-	configFileName := path.Join(configFileDir, "dnsmasq.conf")
-
-	err = os.MkdirAll(configFileDir, os.ModePerm)
-
-	if err != nil {
-		return errors.Wrapf(err, "unable to create config directory")
-	}
-
-	err = os.WriteFile(configFileName, clusterConfigData.Bytes(), 0644)
-
-	if err != nil {
-		return errors.Wrap(err, "failed to write dnsmasq config")
+		return err
 	}
 
 	hostConfig := &container.HostConfig{
@@ -162,6 +116,7 @@ func DeployResolver(domain string, targetAddress string, extraDomains []string) 
 	}
 
 	fmt.Println("Local DNS resolver running as a Docker container", resolverContainerName)
+	fmt.Println("Local DNS resolver configuration in", configFileName)
 
 	return nil
 }
@@ -201,4 +156,90 @@ func DeleteResolver() error {
 	}
 
 	return nil
+}
+
+func UpdateResolver(domain string, targetAddress string, extraDomains []string) error {
+	ctx := context.Background()
+
+	fmt.Println("Updating local DNS resolver configuration")
+
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return errors.Wrap(err, "unable to create docker client")
+	}
+
+	_, err = cli.ContainerInspect(ctx, resolverContainerName)
+	if err != nil {
+		return errors.Wrap(err, "resolver container not found")
+	}
+
+	configFileName, err := generateDnsmasqConfig(domain, targetAddress, extraDomains)
+	if err != nil {
+		return err
+	}
+
+	err = cli.ContainerRestart(ctx, resolverContainerName, container.StopOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to restart resolver")
+	}
+
+	fmt.Println("Local DNS resolver configuration updated and reloaded")
+	fmt.Println("Local DNS resolver configuration in", configFileName)
+
+	return nil
+}
+
+func generateDnsmasqConfig(domain string, targetAddress string, extraDomains []string) (string, error) {
+	dnsmasqConfigTemplate, err := template.New("dnsmasq-config").Parse(dnsmasqConfigTemplateData)
+
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse dnsmasq config template")
+	}
+
+	var clusterConfigData bytes.Buffer
+
+	localIPAddress, err := config.HostIP()
+
+	if err != nil {
+		localIPAddress = "127.0.0.1"
+	}
+
+	if targetAddress == "" {
+		targetAddress = localIPAddress
+	}
+
+	type TemplateConfig struct {
+		IngressDomain string
+		TargetAddress string
+		ExtraDomains  []string
+	}
+
+	config := TemplateConfig{
+		IngressDomain: domain,
+		TargetAddress: targetAddress,
+		ExtraDomains:  extraDomains,
+	}
+
+	err = dnsmasqConfigTemplate.Execute(&clusterConfigData, config)
+
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate dnsmasq config")
+	}
+
+	configFileDir := utils.GetEducatesHomeDir()
+	configFileName := path.Join(configFileDir, "dnsmasq.conf")
+
+	err = os.MkdirAll(configFileDir, os.ModePerm)
+
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to create config directory")
+	}
+
+	err = os.WriteFile(configFileName, clusterConfigData.Bytes(), 0644)
+
+	if err != nil {
+		return "", errors.Wrap(err, "failed to write dnsmasq config")
+	}
+
+	return configFileName, nil
 }

--- a/project-docs/release-notes/version-3.3.0.md
+++ b/project-docs/release-notes/version-3.3.0.md
@@ -1,0 +1,9 @@
+Version 3.3.0
+=============
+
+New Features
+------------
+
+* Added `local resolver update` cli command to reload Resolver container in 
+  case there's a change in local ip assigned to the computer running educates
+  local.


### PR DESCRIPTION
Adds a new command `educates local resolver update` that will generate and update the resolver configuration.
This command is useful to reload the resolver when using the local resolver and your local ip has changed.

Solves #689 

PS: We can review the name of action if you prefer `reload` or `refresh` rather than `update`