### PR TITLE
Fixing lookup ingress when insecure

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/_ytt_lib/lookup-service/overlays.yaml/overlay-ingress.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/_ytt_lib/lookup-service/overlays.yaml/overlay-ingress.yaml
@@ -5,7 +5,7 @@
 ---
 metadata:
   #@overlay/match missing_ok=True
-  #@ if/end data.values.certName != None:
+  #@ if/end data.values.certName:
   annotations:
    ingress.kubernetes.io/force-ssl-redirect: "true"
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -18,7 +18,7 @@ spec:
   #@overlay/match by=overlay.index(0)
   - host: #@ data.values.tld
   #@overlay/match missing_ok=True
-  #@ if/end data.values.certName != None:
+  #@ if/end data.values.certName:
   tls:
   - hosts:
     - #@ data.values.tld


### PR DESCRIPTION
There was an error in the ytt overlay that as certName was defaulted to "", it was always adding the TLS section to lookup-service ingress. This is now fixed.