### PR TITLE
Moving lookup service to port 80

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/_ytt_lib/lookup-service/upstream/ingresses.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/_ytt_lib/lookup-service/upstream/ingresses.yaml
@@ -15,4 +15,4 @@ spec:
           service:
             name: lookup-service
             port:
-              number: 8080
+              number: 80

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/_ytt_lib/lookup-service/upstream/services.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/_ytt_lib/lookup-service/upstream/services.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 8080
+  - port: 80
     targetPort: 8080
   selector:
     app: lookup-service


### PR DESCRIPTION
Modified lookup service to listen on port 80, although container still exposes port 8080. Ingress is also updated.

Fixes #756 