### PR TITLE
Added some workshop command changes/updates

### DIFF
--- a/client-programs/pkg/cmd/cluster_workshop_update_cmd.go
+++ b/client-programs/pkg/cmd/cluster_workshop_update_cmd.go
@@ -11,9 +11,10 @@ import (
 	"path/filepath"
 
 	yttcmd "carvel.dev/ytt/pkg/cmd/template"
+	"github.com/educates/educates-training-platform/client-programs/pkg/cluster"
+	"github.com/educates/educates-training-platform/client-programs/pkg/workshops"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/educates/educates-training-platform/client-programs/pkg/cluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -256,7 +257,7 @@ func loadWorkshopDefinition(name string, path string, portal string, workshopFil
 
 	// Process the workshop YAML data in case it contains ytt templating.
 
-	if workshopData, err = processWorkshopDefinition(workshopData, dataValueFlags); err != nil {
+	if workshopData, err = workshops.ProcessWorkshopDefinition(workshopData, dataValueFlags); err != nil {
 		return nil, errors.Wrap(err, "unable to process workshop definition as template")
 	}
 

--- a/client-programs/pkg/cmd/template_list_cmd.go
+++ b/client-programs/pkg/cmd/template_list_cmd.go
@@ -12,7 +12,7 @@ func (p *ProjectInfo) NewTemplateListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List available workshop templates",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			for _, name := range templates.InternalTemplates() {
+			for _, name := range templates.ListWorkshopTemplates() {
 				cmd.Println(name)
 			}
 

--- a/client-programs/pkg/cmd/workshop_new_cmd.go
+++ b/client-programs/pkg/cmd/workshop_new_cmd.go
@@ -1,65 +1,52 @@
 package cmd
 
 import (
-	"os"
-	"path/filepath"
-	"regexp"
-
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/educates/educates-training-platform/client-programs/pkg/templates"
+	"github.com/educates/educates-training-platform/client-programs/pkg/workshops"
 )
 
-type WorkshopNewOptions struct {
-	Template    string
-	Name        string
-	Title       string
-	Description string
-	Image       string
-}
+var (
+	workshopNewExample = `
+  # Create a new workshop using default hugo template (a directory will be created with my-workshop as name)
+  educates workshop new my-workshop
+
+  # Create a new workshop using default hugo template in /tmp/workshop
+  educates workshop new my-workshop -d /tmp/workshop
+
+  # Create a new workshop using default hugo template in current directory and overwrite existing files
+  educates workshop new my-workshop -d . -y
+
+  # Create a new workshop with custom name
+  educates workshop new my-workshop --name "my-custom-workshop"
+
+  # Create a new workshop with title and description
+  educates workshop new my-workshop --title "Introduction to Kubernetes" --description "Learn the basics of Kubernetes"
+
+  # Create a new workshop with language-specific educates base image. See docs for available images.
+  educates workshop new my-workshop --image 'jdk21-environment:*'
+  educates workshop new my-workshop --image 'conda-environment:*'
+
+  # Create a new workshop with custom base image
+  educates workshop new my-workshop --image ghcr.io/myorg/workshop-base:latest
+
+  # Create a new workshop using the classic template
+  educates workshop new my-workshop --template classic
+
+  # Create a new workshop with no kubernetes access enabled in the workshop
+  educates workshop new my-workshop --no-kubernetes-access
+`
+)
 
 func (p *ProjectInfo) NewWorkshopNewCmd() *cobra.Command {
-	var o WorkshopNewOptions
+	var o workshops.WorkshopNewOptions
 
 	var c = &cobra.Command{
-		Args:  cobra.ExactArgs(1),
-		Use:   "new PATH",
-		Short: "Create workshop files from template",
-		RunE: func(_ *cobra.Command, args []string) error {
-			var err error
-
-			directory := filepath.Clean(args[0])
-
-			if directory, err = filepath.Abs(directory); err != nil {
-				return errors.Wrapf(err, "could not convert path name %q to absolute path", directory)
-			}
-
-			if _, err = os.Stat(directory); err == nil {
-				return errors.Errorf("target path name %q already exists", directory)
-			}
-
-			name := o.Name
-
-			if name == "" {
-				name = filepath.Base(directory)
-			}
-
-			if match, _ := regexp.MatchString("^[a-z0-9-]+$", name); !match {
-				return errors.Errorf("invalid workshop name %q", name)
-			}
-
-			parameters := map[string]string{
-				"WorkshopName":        name,
-				"WorkshopTitle":       o.Title,
-				"WorkshopDescription": o.Description,
-				"WorkshopImage":       o.Image,
-			}
-
-			template := templates.InternalTemplate(o.Template)
-
-			return template.Apply(directory, parameters)
-		},
+		Args:    cobra.ExactArgs(1),
+		Use:     "new PATH",
+		Short:   "Create workshop files from template",
+		RunE:    func(_ *cobra.Command, args []string) error { return o.Run(args) },
+		Example: workshopNewExample,
 	}
 
 	c.Flags().StringVarP(
@@ -67,14 +54,14 @@ func (p *ProjectInfo) NewWorkshopNewCmd() *cobra.Command {
 		"template",
 		"t",
 		"hugo",
-		"name of the workshop template to use",
+		"name of the workshop template to use (hugo, classic)",
 	)
 	c.Flags().StringVarP(
 		&o.Name,
 		"name",
 		"n",
 		"",
-		"override name of the workshop",
+		"override name of the workshop (default: directory name)",
 	)
 	c.Flags().StringVar(
 		&o.Title,
@@ -93,6 +80,34 @@ func (p *ProjectInfo) NewWorkshopNewCmd() *cobra.Command {
 		"image",
 		"",
 		"name of the workshop base image to use",
+	)
+	c.Flags().StringVarP(
+		&o.TargetDirectory,
+		"directory",
+		"d",
+		"",
+		"directory where the workshop will be created. By default a new directory with the workshop name will be created",
+	)
+	c.Flags().BoolVarP(
+		&o.Overwrite,
+		"overwrite",
+		"y",
+		false,
+		"overwrite existing files in the target directory. If not provided, the user will be prompted to confirm the operation.",
+	)
+	c.Flags().BoolVarP(
+		&o.NoKubernetesAccess,
+		"no-kubernetes-access",
+		"",
+		false,
+		"disable kubernetes access in the workshop",
+	)
+	c.Flags().BoolVarP(
+		&o.AddGitHubAction,
+		"add-github-action",
+		"",
+		false,
+		"add GitHub action to the generated workshop",
 	)
 
 	return c

--- a/client-programs/pkg/cmd/workshop_publish_cmd.go
+++ b/client-programs/pkg/cmd/workshop_publish_cmd.go
@@ -1,301 +1,46 @@
 package cmd
 
 import (
-	"bytes"
-	"fmt"
-	"log"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
-	imgpkgcmd "carvel.dev/imgpkg/pkg/imgpkg/cmd"
-	"carvel.dev/kapp/pkg/kapp/cmd"
-	vendirsync "carvel.dev/vendir/pkg/vendir/cmd"
-	yttcmd "carvel.dev/ytt/pkg/cmd/template"
-	yttcmdui "carvel.dev/ytt/pkg/cmd/ui"
-	"carvel.dev/ytt/pkg/files"
-	"carvel.dev/ytt/pkg/yamlmeta"
-	"github.com/cppforlife/go-cli-ui/ui"
-	"github.com/pkg/errors"
+	"github.com/educates/educates-training-platform/client-programs/pkg/workshops"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/kubectl/pkg/scheme"
 )
 
-type FilesPublishOptions struct {
-	Image           string
-	Repository      string
-	WorkshopFile    string
-	ExportWorkshop  string
-	WorkshopVersion string
-	RegistryFlags   imgpkgcmd.RegistryFlags
-	DataValuesFlags yttcmd.DataValuesFlags
-}
+var (
+	workshopPublishExample = `
+  # Publish workshop files to local registry
+  educates workshop publish
 
-func (o *FilesPublishOptions) Run(args []string) error {
-	var err error
+  # Publish workshop files to specific registry
+  educates workshop publish --image-repository ghcr.io/myorg
 
-	var directory string
+  # Publish workshop files with specific version
+  educates workshop publish --workshop-version v1.0.0
 
-	if len(args) != 0 {
-		directory = filepath.Clean(args[0])
-	} else {
-		directory = "."
-	}
+  # Publish workshop files with custom workshop definition
+  educates workshop publish --workshop-file custom-workshop.yaml
 
-	if directory, err = filepath.Abs(directory); err != nil {
-		return errors.Wrap(err, "couldn't convert workshop directory to absolute path")
-	}
+  # Publish workshop files and export modified workshop definition
+  educates workshop publish --export-workshop exported-workshop.yaml
 
-	fileInfo, err := os.Stat(directory)
+  # Publish workshop files with registry authentication
+  educates workshop publish --registry-username user --registry-password pass
 
-	if err != nil || !fileInfo.IsDir() {
-		return errors.New("workshop directory does not exist or path is not a directory")
-	}
-
-	return o.Publish(directory)
-}
-
-func (o *FilesPublishOptions) Publish(directory string) error {
-	// If image name hasn't been supplied read workshop definition file and
-	// try to work out image name to publish workshop as.
-
-	rootDirectory := directory
-	workshopFilePath := o.WorkshopFile
-
-	workingDirectory, err := os.Getwd()
-
-	if err != nil {
-		return errors.Wrap(err, "cannot determine current working directory")
-	}
-
-	includePaths := []string{directory}
-	excludePaths := []string{".git"}
-
-	if !filepath.IsAbs(workshopFilePath) {
-		workshopFilePath = filepath.Join(rootDirectory, workshopFilePath)
-	}
-
-	workshopFileData, err := os.ReadFile(workshopFilePath)
-
-	if err != nil {
-		return errors.Wrapf(err, "cannot open workshop definition %q", workshopFilePath)
-	}
-
-	// Process the workshop YAML data for ytt templating and data variables.
-
-	if workshopFileData, err = processWorkshopDefinition(workshopFileData, o.DataValuesFlags); err != nil {
-		return errors.Wrap(err, "unable to process workshop definition as template")
-	}
-
-	workshopFileData = []byte(strings.ReplaceAll(string(workshopFileData), "$(image_repository)", o.Repository))
-	workshopFileData = []byte(strings.ReplaceAll(string(workshopFileData), "$(workshop_version)", o.WorkshopVersion))
-
-	decoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDecoder()
-
-	workshop := &unstructured.Unstructured{}
-
-	err = runtime.DecodeInto(decoder, workshopFileData, workshop)
-
-	if err != nil {
-		return errors.Wrap(err, "couldn't parse workshop definition")
-	}
-
-	fmt.Printf("Processing workshop with name %q.\n", workshop.GetName())
-
-	if workshop.GetAPIVersion() != "training.educates.dev/v1beta1" || workshop.GetKind() != "Workshop" {
-		return errors.New("invalid type for workshop definition")
-	}
-
-	image := o.Image
-
-	if image == "" {
-		image, _, _ = unstructured.NestedString(workshop.Object, "spec", "publish", "image")
-	}
-
-	if image == "" {
-		return errors.Errorf("cannot find image name for publishing workshop %q", workshopFilePath)
-	}
-
-	// Extract vendir snippet describing subset of files to package up as the
-	// workshop image.
-
-	confUI := ui.NewConfUI(ui.NewNoopLogger())
-
-	uiFlags := cmd.UIFlags{
-		Color:          true,
-		JSON:           false,
-		NonInteractive: true,
-	}
-
-	uiFlags.ConfigureUI(confUI)
-
-	defer confUI.Flush()
-
-	if fileArtifacts, found, _ := unstructured.NestedSlice(workshop.Object, "spec", "publish", "files"); found && len(fileArtifacts) != 0 {
-		tempDir, err := os.MkdirTemp("", "educates-imgpkg")
-
-		if err != nil {
-			return errors.Wrapf(err, "unable to create temporary working directory")
-		}
-
-		defer os.RemoveAll(tempDir)
-
-		for _, artifactEntry := range fileArtifacts {
-			vendirConfig := map[string]interface{}{
-				"apiVersion":  "vendir.k14s.io/v1alpha1",
-				"kind":        "Config",
-				"directories": []interface{}{},
-			}
-
-			dir := filepath.Join(tempDir, "files")
-
-			if filePath, found := artifactEntry.(map[string]interface{})["path"].(string); found {
-				dir = filepath.Join(tempDir, "files", filepath.Clean(filePath))
-			}
-
-			if directoryConfig, found := artifactEntry.(map[string]interface{})["directory"]; found {
-				if directoryPath, found := directoryConfig.(map[string]interface{})["path"].(string); found {
-					if !filepath.IsAbs(directoryPath) {
-						directoryConfig.(map[string]interface{})["path"] = filepath.Join(directory, directoryPath)
-					}
-				}
-			}
-
-			artifactEntry.(map[string]interface{})["path"] = "."
-
-			directoryConfig := map[string]interface{}{
-				"path":     dir,
-				"contents": []interface{}{artifactEntry},
-			}
-
-			vendirConfig["directories"] = append(vendirConfig["directories"].([]interface{}), directoryConfig)
-
-			yamlData, err := yaml.Marshal(&vendirConfig)
-
-			if err != nil {
-				return errors.Wrap(err, "unable to generate vendir config")
-			}
-
-			vendirConfigFile, err := os.Create(filepath.Join(tempDir, "vendir.yml"))
-
-			if err != nil {
-				return errors.Wrap(err, "unable to create vendir config file")
-			}
-
-			defer vendirConfigFile.Close()
-
-			_, err = vendirConfigFile.Write(yamlData)
-
-			if err != nil {
-				return errors.Wrap(err, "unable to write vendir config file")
-			}
-
-			syncOptions := vendirsync.NewSyncOptions(confUI)
-
-			syncOptions.Directories = nil
-			syncOptions.Files = []string{filepath.Join(tempDir, "vendir.yml")}
-
-			// Note that Chdir here actually changes the process working directory.
-
-			syncOptions.LockFile = filepath.Join(tempDir, "lock-file")
-			syncOptions.Locked = false
-			syncOptions.Chdir = tempDir
-			syncOptions.AllowAllSymlinkDestinations = false
-
-			if err = syncOptions.Run(); err != nil {
-				fmt.Println(string(yamlData))
-
-				return errors.Wrap(err, "failed to prepare image files for publishing")
-			}
-		}
-
-		// Restore working directory as was changed.
-
-		os.Chdir((workingDirectory))
-
-		rootDirectory = filepath.Join(tempDir, "files")
-		includePaths = []string{rootDirectory}
-	}
-
-	// Now publish workshop directory contents as OCI image artifact.
-
-	fmt.Printf("Publishing workshop files to %q.\n", image)
-
-	pushOptions := imgpkgcmd.NewPushOptions(confUI)
-
-	pushOptions.ImageFlags.Image = image
-	pushOptions.FileFlags.Files = append(pushOptions.FileFlags.Files, includePaths...)
-	pushOptions.FileFlags.ExcludedFilePaths = append(pushOptions.FileFlags.ExcludedFilePaths, excludePaths...)
-
-	pushOptions.RegistryFlags = o.RegistryFlags
-
-	err = pushOptions.Run()
-
-	if err != nil {
-		return errors.Wrap(err, "unable to push image artifact for workshop")
-	}
-
-	// We add a newline to output for better readability.
-	fmt.Println()
-
-	// Export modified workshop definition file.
-
-	exportWorkshop := o.ExportWorkshop
-
-	if exportWorkshop != "" {
-		// Insert workshop version property if not specified.
-
-		_, found, _ := unstructured.NestedString(workshop.Object, "spec", "version")
-
-		if !found && o.WorkshopVersion != "latest" {
-			unstructured.SetNestedField(workshop.Object, o.WorkshopVersion, "spec", "version")
-		}
-
-		// Remove the publish section as will not be accurate after publising.
-
-		unstructured.RemoveNestedField(workshop.Object, "spec", "publish")
-
-		workshopFileData, err = yaml.Marshal(&workshop.Object)
-
-		if err != nil {
-			return errors.Wrap(err, "couldn't convert workshop definition back to YAML")
-		}
-
-		if !filepath.IsAbs(exportWorkshop) {
-			exportWorkshop = filepath.Join(workingDirectory, exportWorkshop)
-		}
-
-		exportWorkshopFile, err := os.Create(exportWorkshop)
-
-		if err != nil {
-			return errors.Wrap(err, "unable to create exported workshop definition file")
-		}
-
-		defer exportWorkshopFile.Close()
-
-		_, err = exportWorkshopFile.Write(workshopFileData)
-
-		if err != nil {
-			return errors.Wrap(err, "unable to write exported workshop definition file")
-		}
-	}
-
-	return nil
-}
+  # Publish workshop files with data values
+  educates workshop publish --data-value workshop.title="My Workshop" --data-value workshop.description="A great workshop"
+`
+)
 
 func (p *ProjectInfo) NewWorkshopPublishCmd() *cobra.Command {
-	var o FilesPublishOptions
+	var o workshops.FilesPublishOptions
 
 	var c = &cobra.Command{
-		Args:  cobra.MaximumNArgs(1),
-		Use:   "publish [PATH]",
-		Short: "Publish workshop files to repository",
-		RunE:  func(cmd *cobra.Command, args []string) error { return o.Run(args) },
+		Args:    cobra.MaximumNArgs(1),
+		Use:     "publish [PATH]",
+		Short:   "Publish workshop files to repository",
+		RunE:    func(cmd *cobra.Command, args []string) error { return o.Run(args) },
+		Example: workshopPublishExample,
 	}
 
 	c.Flags().StringVar(
@@ -426,36 +171,4 @@ func (p *ProjectInfo) NewWorkshopPublishCmd() *cobra.Command {
 	)
 
 	return c
-}
-
-func processWorkshopDefinition(yamlData []byte, dataValueFlags yttcmd.DataValuesFlags) ([]byte, error) {
-	templatingOptions := yttcmd.NewOptions()
-
-	templatingOptions.IgnoreUnknownComments = true
-
-	templatingOptions.DataValuesFlags = dataValueFlags
-
-	var filesToProcess []*files.File
-
-	mainInputFile := files.MustNewFileFromSource(files.NewBytesSource("workshop.yaml", yamlData))
-
-	filesToProcess = append(filesToProcess, mainInputFile)
-
-	logUI := yttcmdui.NewCustomWriterTTY(false, log.Writer(), log.Writer())
-
-	output := templatingOptions.RunWithFiles(yttcmd.Input{Files: filesToProcess}, logUI)
-
-	if output.Err != nil {
-		return []byte{}, fmt.Errorf("execution of ytt failed: %s", output.Err)
-	}
-
-	if len(output.DocSet.Items) == 0 {
-		return []byte{}, nil
-	}
-
-	var buf bytes.Buffer
-
-	yamlmeta.NewYAMLPrinter(&buf).Print(output.DocSet.Items[0])
-
-	return buf.Bytes(), nil
 }

--- a/client-programs/pkg/templates/files/classic/resources/workshop.yaml
+++ b/client-programs/pkg/templates/files/classic/resources/workshop.yaml
@@ -21,6 +21,9 @@ spec:
   session:
     namespaces:
       budget: medium
+      security:
+        token:
+          enabled: {{ .NoKubernetesAccess }}      
     applications:
       terminal:
         enabled: true

--- a/client-programs/pkg/templates/files/hugo/resources/workshop.yaml
+++ b/client-programs/pkg/templates/files/hugo/resources/workshop.yaml
@@ -21,6 +21,9 @@ spec:
   session:
     namespaces:
       budget: medium
+      security:
+        token:
+          enabled: {{ .NoKubernetesAccess }}      
     applications:
       terminal:
         enabled: true

--- a/client-programs/pkg/templates/github/single/.github/workflows/publish-workshop.yaml
+++ b/client-programs/pkg/templates/github/single/.github/workflows/publish-workshop.yaml
@@ -1,0 +1,22 @@
+name: Publish Workshop
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-alpha.[0-9]+"
+      - "[0-9]+.[0-9]+-beta.[0-9]+"
+      - "[0-9]+.[0-9]+-rc.[0-9]+"
+
+jobs:
+  publish-workshop:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create release
+        uses: educates/educates-github-actions/publish-workshop@v7
+        with:
+          token: {{ "${{secrets.GITHUB_TOKEN}}" }}

--- a/client-programs/pkg/utils/prompt.go
+++ b/client-programs/pkg/utils/prompt.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// YesNoPrompt prompts the user for a yes/no answer to a question.
+// It returns true if the user answers yes, false if the user answers no, and the default value if the user does not answer.
+func YesNoPrompt(label string, def bool) bool {
+	choices := "Y/n"
+	if !def {
+		choices = "y/N"
+	}
+
+	r := bufio.NewReader(os.Stdin)
+	var s string
+
+	for {
+		fmt.Fprintf(os.Stderr, "%s (%s) ", label, choices)
+		s, _ = r.ReadString('\n')
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return def
+		}
+		s = strings.ToLower(s)
+		if s == "y" || s == "yes" {
+			return true
+		}
+		if s == "n" || s == "no" {
+			return false
+		}
+	}
+}

--- a/client-programs/pkg/workshops/export.go
+++ b/client-programs/pkg/workshops/export.go
@@ -1,0 +1,108 @@
+package workshops
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	yttcmd "carvel.dev/ytt/pkg/cmd/template"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+type FilesExportOptions struct {
+	Repository      string
+	WorkshopFile    string
+	WorkshopVersion string
+	DataValuesFlags yttcmd.DataValuesFlags
+}
+
+func (o *FilesExportOptions) Run(args []string) error {
+	var err error
+
+	var workshopDir string
+
+	if len(args) != 0 {
+		workshopDir = filepath.Clean(args[0])
+	} else {
+		workshopDir = "."
+	}
+
+	if workshopDir, err = filepath.Abs(workshopDir); err != nil {
+		return errors.Wrap(err, "couldn't convert workshop directory to absolute path")
+	}
+
+	fileInfo, err := os.Stat(workshopDir)
+
+	if err != nil || !fileInfo.IsDir() {
+		return errors.New("workshop directory does not exist or path is not a directory")
+	}
+
+	return o.Export(workshopDir)
+}
+
+func (o *FilesExportOptions) Export(workshopDir string) error {
+	rootDirectory := workshopDir
+	workshopFilePath := o.WorkshopFile
+
+	// 1. Find the workshop definition file
+	if !filepath.IsAbs(workshopFilePath) {
+		workshopFilePath = filepath.Join(rootDirectory, workshopFilePath)
+	}
+
+	workshopFileData, err := os.ReadFile(workshopFilePath)
+
+	if err != nil {
+		return errors.Wrapf(err, "cannot open workshop definition %q", workshopFilePath)
+	}
+
+	// 2. Process the workshop definition file through the ytt templating engine
+	if workshopFileData, err = ProcessWorkshopDefinition(workshopFileData, o.DataValuesFlags); err != nil {
+		return errors.Wrap(err, "unable to process workshop definition as template")
+	}
+
+	// 3. Replace the image repository and workshop version placeholders with the actual values valid for exporting and publishing
+	workshopFileData = []byte(strings.ReplaceAll(string(workshopFileData), "$(image_repository)", o.Repository))
+	workshopFileData = []byte(strings.ReplaceAll(string(workshopFileData), "$(workshop_version)", o.WorkshopVersion))
+
+	// 4. Decode the workshop definition and perform validations
+	decoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDecoder()
+
+	workshop := &unstructured.Unstructured{}
+
+	err = runtime.DecodeInto(decoder, workshopFileData, workshop)
+
+	if err != nil {
+		return errors.Wrap(err, "couldn't parse workshop definition")
+	}
+
+	if workshop.GetAPIVersion() != "training.educates.dev/v1beta1" || workshop.GetKind() != "Workshop" {
+		return errors.New("invalid type for workshop definition")
+	}
+
+	_, found, _ := unstructured.NestedString(workshop.Object, "spec", "version")
+
+	if !found && o.WorkshopVersion != "latest" {
+		unstructured.SetNestedField(workshop.Object, o.WorkshopVersion, "spec", "version")
+	}
+
+	// 5. Remove the publish field from the workshop definition
+	unstructured.RemoveNestedField(workshop.Object, "spec", "publish")
+
+	// 6. Convert the workshop definition back to YAML format
+	workshopFileData, err = yaml.Marshal(&workshop.Object)
+
+	if err != nil {
+		return errors.Wrap(err, "couldn't convert workshop definition back to YAML")
+	}
+
+	// 7. Print the workshop definition to stdout
+	fmt.Print(string(workshopFileData))
+
+	return nil
+}

--- a/client-programs/pkg/workshops/new.go
+++ b/client-programs/pkg/workshops/new.go
@@ -1,0 +1,89 @@
+package workshops
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"github.com/educates/educates-training-platform/client-programs/pkg/templates"
+	"github.com/educates/educates-training-platform/client-programs/pkg/utils"
+	"github.com/pkg/errors"
+)
+
+type WorkshopNewOptions struct {
+	Template           string
+	Name               string
+	Title              string
+	Description        string
+	Image              string
+	TargetDirectory    string
+	Overwrite          bool
+	NoKubernetesAccess bool
+	AddGitHubAction    bool
+}
+
+// If o.TargetDirectory is provided, we will use that as the directory to be used, otherwise a new one will be created
+func (o *WorkshopNewOptions) Run(args []string) error {
+	var err error
+
+	workshopDir := filepath.Clean(args[0])
+	if o.TargetDirectory != "" {
+		workshopDir = o.TargetDirectory
+	}
+
+	if workshopDir, err = filepath.Abs(workshopDir); err != nil {
+		return errors.Wrapf(err, "could not convert path name %q to absolute path", workshopDir)
+	}
+
+	if o.TargetDirectory == "" {
+		if _, err = os.Stat(workshopDir); err == nil {
+			return errors.Errorf("target path name %q already exists", workshopDir)
+		}
+	} else {
+		// Check if target directory already exist and prompt the user to confirm that they want to overwrite the files in it
+		if _, err = os.Stat(workshopDir); err == nil {
+			ok := o.Overwrite
+			if !o.Overwrite {
+				ok = utils.YesNoPrompt(fmt.Sprintf("the directory %q already exists. All files will be overwritten. Do you want to use it?", workshopDir), true)
+			}
+			if !ok {
+				return errors.Errorf("operation cancelled")
+			}
+		}
+
+	}
+
+	name := o.Name
+
+	if name == "" {
+		name = filepath.Base(workshopDir)
+	}
+
+	if match, _ := regexp.MatchString("^[a-z0-9-]+$", name); !match {
+		return errors.Errorf("invalid workshop name %q. It can only contain lowercase letters, numbers, and hyphens", name)
+	}
+
+	parameters := map[string]string{
+		"WorkshopName":        name,
+		"WorkshopTitle":       o.Title,
+		"WorkshopDescription": o.Description,
+		"WorkshopImage":       o.Image,
+		"NoKubernetesAccess":  strconv.FormatBool(o.NoKubernetesAccess),
+	}
+
+	template := templates.InternalTemplate(o.Template)
+
+	err = template.ApplyFiles(workshopDir, parameters)
+	if err != nil {
+		return err
+	}
+
+	if o.AddGitHubAction {
+		template := templates.InternalTemplate("single")
+		err = template.ApplyGitHubAction(workshopDir, parameters)
+	}
+
+	return err
+}

--- a/client-programs/pkg/workshops/publish.go
+++ b/client-programs/pkg/workshops/publish.go
@@ -1,0 +1,325 @@
+package workshops
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	imgpkgcmd "carvel.dev/imgpkg/pkg/imgpkg/cmd"
+	"carvel.dev/kapp/pkg/kapp/cmd"
+	vendirsync "carvel.dev/vendir/pkg/vendir/cmd"
+	yttcmd "carvel.dev/ytt/pkg/cmd/template"
+	yttcmdui "carvel.dev/ytt/pkg/cmd/ui"
+	"carvel.dev/ytt/pkg/files"
+	"carvel.dev/ytt/pkg/yamlmeta"
+	"github.com/cppforlife/go-cli-ui/ui"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+type FilesPublishOptions struct {
+	Image           string
+	Repository      string
+	WorkshopFile    string
+	ExportWorkshop  string
+	WorkshopVersion string
+	RegistryFlags   imgpkgcmd.RegistryFlags
+	DataValuesFlags yttcmd.DataValuesFlags
+}
+
+func (o *FilesPublishOptions) Run(args []string) error {
+	var err error
+
+	var workshopDir string
+
+	if len(args) != 0 {
+		workshopDir = filepath.Clean(args[0])
+	} else {
+		workshopDir = "."
+	}
+
+	if workshopDir, err = filepath.Abs(workshopDir); err != nil {
+		return errors.Wrap(err, "couldn't convert workshop directory to absolute path")
+	}
+
+	fileInfo, err := os.Stat(workshopDir)
+
+	if err != nil || !fileInfo.IsDir() {
+		return errors.New("workshop directory does not exist or path is not a workshopDir")
+	}
+
+	return o.Publish(workshopDir)
+}
+
+func (o *FilesPublishOptions) Publish(workshopDir string) error {
+	// If image name hasn't been supplied read workshop definition file and
+	// try to work out image name to publish workshop as.
+
+	rootDirectory := workshopDir
+	workshopFilePath := o.WorkshopFile
+
+	workingDirectory, err := os.Getwd()
+
+	if err != nil {
+		return errors.Wrap(err, "cannot determine current working directory")
+	}
+
+	includePaths := []string{workshopDir}
+	excludePaths := []string{".git"}
+
+	if !filepath.IsAbs(workshopFilePath) {
+		workshopFilePath = filepath.Join(rootDirectory, workshopFilePath)
+	}
+
+	workshopFileData, err := os.ReadFile(workshopFilePath)
+
+	if err != nil {
+		return errors.Wrapf(err, "cannot open workshop definition %q", workshopFilePath)
+	}
+
+	// Process the workshop YAML data for ytt templating and data variables.
+
+	if workshopFileData, err = ProcessWorkshopDefinition(workshopFileData, o.DataValuesFlags); err != nil {
+		return errors.Wrap(err, "unable to process workshop definition as template")
+	}
+
+	workshopFileData = []byte(strings.ReplaceAll(string(workshopFileData), "$(image_repository)", o.Repository))
+	workshopFileData = []byte(strings.ReplaceAll(string(workshopFileData), "$(workshop_version)", o.WorkshopVersion))
+
+	decoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDecoder()
+
+	workshop := &unstructured.Unstructured{}
+
+	err = runtime.DecodeInto(decoder, workshopFileData, workshop)
+
+	if err != nil {
+		return errors.Wrap(err, "couldn't parse workshop definition")
+	}
+
+	fmt.Printf("Processing workshop with name %q.\n", workshop.GetName())
+
+	if workshop.GetAPIVersion() != "training.educates.dev/v1beta1" || workshop.GetKind() != "Workshop" {
+		return errors.New("invalid type for workshop definition")
+	}
+
+	image := o.Image
+
+	if image == "" {
+		image, _, _ = unstructured.NestedString(workshop.Object, "spec", "publish", "image")
+	}
+
+	if image == "" {
+		return errors.Errorf("cannot find image name for publishing workshop %q", workshopFilePath)
+	}
+
+	// Extract vendir snippet describing subset of files to package up as the
+	// workshop image.
+
+	confUI := ui.NewConfUI(ui.NewNoopLogger())
+
+	uiFlags := cmd.UIFlags{
+		Color:          true,
+		JSON:           false,
+		NonInteractive: true,
+	}
+
+	uiFlags.ConfigureUI(confUI)
+
+	defer confUI.Flush()
+
+	if fileArtifacts, found, _ := unstructured.NestedSlice(workshop.Object, "spec", "publish", "files"); found && len(fileArtifacts) != 0 {
+		tempDir, err := os.MkdirTemp("", "educates-imgpkg")
+
+		if err != nil {
+			return errors.Wrapf(err, "unable to create temporary working directory")
+		}
+
+		defer os.RemoveAll(tempDir)
+
+		for _, artifactEntry := range fileArtifacts {
+			vendirConfig := map[string]interface{}{
+				"apiVersion":  "vendir.k14s.io/v1alpha1",
+				"kind":        "Config",
+				"directories": []interface{}{},
+			}
+
+			dir := filepath.Join(tempDir, "files")
+
+			if filePath, found := artifactEntry.(map[string]interface{})["path"].(string); found {
+				dir = filepath.Join(tempDir, "files", filepath.Clean(filePath))
+			}
+
+			if directoryConfig, found := artifactEntry.(map[string]interface{})["workshopDir"]; found {
+				if directoryPath, found := directoryConfig.(map[string]interface{})["path"].(string); found {
+					if !filepath.IsAbs(directoryPath) {
+						directoryConfig.(map[string]interface{})["path"] = filepath.Join(workshopDir, directoryPath)
+					}
+				}
+			}
+
+			artifactEntry.(map[string]interface{})["path"] = "."
+
+			directoryConfig := map[string]interface{}{
+				"path":     dir,
+				"contents": []interface{}{artifactEntry},
+			}
+
+			vendirConfig["directories"] = append(vendirConfig["directories"].([]interface{}), directoryConfig)
+
+			yamlData, err := yaml.Marshal(&vendirConfig)
+
+			if err != nil {
+				return errors.Wrap(err, "unable to generate vendir config")
+			}
+
+			vendirConfigFile, err := os.Create(filepath.Join(tempDir, "vendir.yml"))
+
+			if err != nil {
+				return errors.Wrap(err, "unable to create vendir config file")
+			}
+
+			defer vendirConfigFile.Close()
+
+			_, err = vendirConfigFile.Write(yamlData)
+
+			if err != nil {
+				return errors.Wrap(err, "unable to write vendir config file")
+			}
+
+			syncOptions := vendirsync.NewSyncOptions(confUI)
+
+			syncOptions.Directories = nil
+			syncOptions.Files = []string{filepath.Join(tempDir, "vendir.yml")}
+
+			// Note that Chdir here actually changes the process working workshopDir.
+
+			syncOptions.LockFile = filepath.Join(tempDir, "lock-file")
+			syncOptions.Locked = false
+			syncOptions.Chdir = tempDir
+			syncOptions.AllowAllSymlinkDestinations = false
+
+			if err = syncOptions.Run(); err != nil {
+				fmt.Println(string(yamlData))
+
+				return errors.Wrap(err, "failed to prepare image files for publishing")
+			}
+		}
+
+		// Restore working workshopDir as was changed.
+
+		os.Chdir((workingDirectory))
+
+		rootDirectory = filepath.Join(tempDir, "files")
+		includePaths = []string{rootDirectory}
+	}
+
+	// Now publish workshop workshopDir contents as OCI image artifact.
+
+	fmt.Printf("Publishing workshop files to %q.\n", image)
+
+	pushOptions := imgpkgcmd.NewPushOptions(confUI)
+
+	pushOptions.ImageFlags.Image = image
+	pushOptions.FileFlags.Files = append(pushOptions.FileFlags.Files, includePaths...)
+	pushOptions.FileFlags.ExcludedFilePaths = append(pushOptions.FileFlags.ExcludedFilePaths, excludePaths...)
+
+	pushOptions.RegistryFlags = o.RegistryFlags
+
+	err = pushOptions.Run()
+
+	if err != nil {
+		return errors.Wrap(err, "unable to push image artifact for workshop")
+	}
+
+	// We add a newline to output for better readability.
+	fmt.Println()
+
+	// Export modified workshop definition file.
+
+	exportWorkshop := o.ExportWorkshop
+
+	if exportWorkshop != "" {
+		// Insert workshop version property if not specified.
+
+		_, found, _ := unstructured.NestedString(workshop.Object, "spec", "version")
+
+		if !found && o.WorkshopVersion != "latest" {
+			unstructured.SetNestedField(workshop.Object, o.WorkshopVersion, "spec", "version")
+		}
+
+		// Remove the publish section as will not be accurate after publising.
+
+		unstructured.RemoveNestedField(workshop.Object, "spec", "publish")
+
+		workshopFileData, err = yaml.Marshal(&workshop.Object)
+
+		if err != nil {
+			return errors.Wrap(err, "couldn't convert workshop definition back to YAML")
+		}
+
+		if !filepath.IsAbs(exportWorkshop) {
+			exportWorkshop = filepath.Join(workingDirectory, exportWorkshop)
+		}
+
+		exportWorkshopFile, err := os.Create(exportWorkshop)
+
+		if err != nil {
+			return errors.Wrap(err, "unable to create exported workshop definition file")
+		}
+
+		defer exportWorkshopFile.Close()
+
+		_, err = exportWorkshopFile.Write(workshopFileData)
+
+		if err != nil {
+			return errors.Wrap(err, "unable to write exported workshop definition file")
+		}
+	}
+
+	return nil
+}
+
+/*
+ * ProcessWorkshopDefinition processes a workshop YAML definition file through the ytt templating engine.
+ * It takes the raw YAML data as input along with any data value flags for template variable substitution.
+ * The function returns the processed YAML with template variables replaced, or an error if processing fails.
+ */
+
+func ProcessWorkshopDefinition(yamlData []byte, dataValueFlags yttcmd.DataValuesFlags) ([]byte, error) {
+	templatingOptions := yttcmd.NewOptions()
+
+	templatingOptions.IgnoreUnknownComments = true
+
+	templatingOptions.DataValuesFlags = dataValueFlags
+
+	var filesToProcess []*files.File
+
+	mainInputFile := files.MustNewFileFromSource(files.NewBytesSource("workshop.yaml", yamlData))
+
+	filesToProcess = append(filesToProcess, mainInputFile)
+
+	logUI := yttcmdui.NewCustomWriterTTY(false, log.Writer(), log.Writer())
+
+	output := templatingOptions.RunWithFiles(yttcmd.Input{Files: filesToProcess}, logUI)
+
+	if output.Err != nil {
+		return []byte{}, fmt.Errorf("execution of ytt failed: %s", output.Err)
+	}
+
+	if len(output.DocSet.Items) == 0 {
+		return []byte{}, nil
+	}
+
+	var buf bytes.Buffer
+
+	yamlmeta.NewYAMLPrinter(&buf).Print(output.DocSet.Items[0])
+
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
Have done some refactoring of the workshop commands so that now common code lives in pkg/workshops for better reusability.
Also have done:
- added current dir as an option for new-workshop. (Fixes #755)
- Add GitHub workflow single workshop publish action as flag to new-workshop `--add-github-action`(Fixes #441 
- Add configuration to easily disable kubernetes access in new -workshop via flag `--no-kubernetes-access` (Fixes #430). The configuration is now always there although by default is enabled for backwards compatibility. This makes it easier for a user to disable the setting as the value is in the workshop definition by default.