### PR TITLE
fix(secrets-manager): remove bogus sourceSecret property from SecretImporter CRD

### DIFF
--- a/installer/charts/educates-training-platform/charts/secrets-manager/crds/secretimporter.yaml
+++ b/installer/charts/educates-training-platform/charts/secrets-manager/crds/secretimporter.yaml
@@ -24,13 +24,6 @@ spec:
             spec:
               type: object
               properties:
-                sourceSecret:
-                  type: object
-                  required:
-                  - name
-                  properties:
-                    name:
-                      type: string
                 sourceNamespaces:
                   type: object
                   properties:

--- a/project-docs/custom-resources/secret-importer.md
+++ b/project-docs/custom-resources/secret-importer.md
@@ -98,25 +98,6 @@ spec:
     sharedSecret: my-shared-secret
 ```
 
-Because secrets can be renamed in the process of being copied, this can be further qualified by identifying by name the source secret in the source namespace.
-
-```yaml
-apiVersion: secrets.educates.dev/v1beta1
-kind: SecretImporter
-metadata:
-  name: registry-credentials
-  namespace: developer-namespace
-spec:
-  sourceSecret:
-    name: registry-credentials
-  sourceNamespaces:
-    nameSelector:
-      matchNames:
-      - registry
-  copyAuthorization:
-    sharedSecret: my-shared-secret
-```
-
 Deletion of the secret importer
 -------------------------------
 

--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -503,3 +503,13 @@ Bugs Fixed
   the time which has elapsed since the workshop session was allocated to the
   user when checking whether a workshop session should be deleted due to
   being orphaned or inactive.
+
+* The custom resource definition for the ``SecretImporter`` resource declared
+  a ``sourceSecret`` property in its schema, and the documentation described
+  it as a way of qualifying by name which source secret could be copied. This
+  property was never consulted by the secrets manager, as the name of the
+  secret a ``SecretImporter`` accepts is always determined from the name of
+  the ``SecretImporter`` resource itself. The unused property has been
+  removed from the custom resource definition and the documentation. If you
+  had set ``sourceSecret`` in a ``SecretImporter`` resource it had no effect,
+  and the field should be removed from your manifests.


### PR DESCRIPTION
The `SecretImporter` custom resource definition declared a `sourceSecret`
property in its schema, and the documentation described it as a way of
qualifying by name which source secret could be copied. The secrets manager
never reads this property: the secret a `SecretImporter` accepts is always
determined from the name of the `SecretImporter` resource itself, and the
source secret name comes from the `SecretCopier` or `SecretExporter` rule.

This removes the unused property from the CRD schema, drops the
documentation section that described the non-existent behaviour, and adds a
release notes entry for 4.0.0 noting that manifests which set the field
should remove it, since strict `kubectl` field validation would reject the
field once the schema no longer declares it.

Fixes #1036
