### PR TITLE
fix(docker-registry): raise patched module pins in the registry source rebuild

### DIFF
--- a/docker-registry/Dockerfile
+++ b/docker-registry/Dockerfile
@@ -18,8 +18,9 @@ RUN <<EOF
     cd /distribution
     test "$(git rev-parse HEAD)" = "${DISTRIBUTION_COMMIT}"
     go get \
-        golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
+        golang.org/x/crypto@v0.54.0 \
+        golang.org/x/net@v0.57.0 \
+        golang.org/x/text@v0.41.0 \
         google.golang.org/grpc@v1.82.1
     go mod tidy
     go mod vendor


### PR DESCRIPTION
3.8-line counterpart of educates/educates-training-platform#1169. The registry source rebuild on this branch pinned x/crypto and x/net but had no x/text pin, so as well as raising the shared pins this adds one:

| module | before | after |
|--------|--------|-------|
| golang.org/x/net | v0.55.0 | v0.57.0 |
| golang.org/x/crypto | v0.52.0 | v0.54.0 |
| golang.org/x/text | (unpinned, resolves 0.37.0) | v0.41.0 |

The x/net bump clears `CVE-2026-46600` (fixed in 0.56.0) and the new x/text pin clears `CVE-2026-56852` (fixed in 0.39.0), which the unpinned resolution was exposed to.

Verified by rebuild and rescan on this branch: the image built from this Dockerfile scans 0 CRITICAL / 0 HIGH with trivy (both the alpine base and the rebuilt `bin/registry` binary).