### PR TITLE
fix(image-cache): update zot registry to 2.1.20

### DIFF
--- a/image-cache/Dockerfile
+++ b/image-cache/Dockerfile
@@ -12,9 +12,9 @@ WORKDIR /opt/app-root/src
 
 RUN <<EOF
     set -eo pipefail
-    VERSION=2.1.18
-    CHECKSUM_amd64="a359a0af159db6758b24f8e26d6a244aae95caf3ff382c462875f42d9e082898"
-    CHECKSUM_arm64="0504b0bd926a7ca9dab71055ba0e0bca8ae4bd67159ef4b8ee3855dcc38818c9"
+    VERSION=2.1.20
+    CHECKSUM_amd64="a32e42d042d1f17b5b1317e55cc1a415a744c873dcd05c25c56b665478258bcb"
+    CHECKSUM_arm64="d6a39475587be18ec3d42e0d2bfa50f5c5064cbbcdc222dbd88e55ecf69dd8e9"
     CHECKSUM=CHECKSUM_${TARGETARCH}
     curl --silent --fail -L -o /usr/bin/zot https://github.com/project-zot/zot/releases/download/v${VERSION}/zot-linux-${TARGETARCH}
     echo "${!CHECKSUM}  /usr/bin/zot" | sha256sum --check --status


### PR DESCRIPTION
Bump the zot registry binary in the image-cache image from 2.1.18 to 2.1.20 (the latest release; checksums from upstream's `checksums.sha256.txt`).

Verified by rebuild and rescan. What the bump clears and what it does not:

**Cleared:** `CVE-2026-50163` (oras-go, now 2.6.2), the x/text advisory (now 0.40.0) and the grpc advisory (now 1.82.1).

**Remaining (11 HIGH):** upstream's 2.1.20 binaries are built with Go 1.26.5, so the stdlib wave fixed in 1.26.6 persists (8 rows), along with go-git 5.19.1 (`CVE-2026-71556`, fixed 5.19.2) and two x/mod advisories that are new in the current vulnerability DB (`CVE-2026-56864/56865`, fixed 0.40.0). Clearing those would need a source rebuild with a pinned toolchain and dependency bumps, the treatment already applied to the docker-registry binary — noted as a follow-up decision, not part of this change.

Functional check: the rebuilt image's zot reports v2.1.20, distribution-spec 1.1.1. The 2.1.19/2.1.20 changelogs carry no configuration-shape changes, so the zot 2.x config written by session-manager is unaffected.

A matching PR against `release/3.8.0` carries the identical change (both branches pinned 2.1.18 with identical checksums).