### PR TITLE
fix(image-cache): update zot registry to 2.1.20

### DIFF
--- a/image-cache/Dockerfile
+++ b/image-cache/Dockerfile
@@ -12,9 +12,9 @@ WORKDIR /opt/app-root/src
 
 RUN <<EOF
     set -eo pipefail
-    VERSION=2.1.18
-    CHECKSUM_amd64="a359a0af159db6758b24f8e26d6a244aae95caf3ff382c462875f42d9e082898"
-    CHECKSUM_arm64="0504b0bd926a7ca9dab71055ba0e0bca8ae4bd67159ef4b8ee3855dcc38818c9"
+    VERSION=2.1.20
+    CHECKSUM_amd64="a32e42d042d1f17b5b1317e55cc1a415a744c873dcd05c25c56b665478258bcb"
+    CHECKSUM_arm64="d6a39475587be18ec3d42e0d2bfa50f5c5064cbbcdc222dbd88e55ecf69dd8e9"
     CHECKSUM=CHECKSUM_${TARGETARCH}
     curl --silent --fail -L -o /usr/bin/zot https://github.com/project-zot/zot/releases/download/v${VERSION}/zot-linux-${TARGETARCH}
     echo "${!CHECKSUM}  /usr/bin/zot" | sha256sum --check --status


### PR DESCRIPTION
3.8-line counterpart of educates/educates-training-platform#1173 — byte-identical change (both branches pinned zot 2.1.18 with identical checksums).

Bump the zot registry binary from 2.1.18 to 2.1.20. Clears `CVE-2026-50163` (oras-go 2.6.2), the x/text advisory (0.40.0) and the grpc advisory (1.82.1). Upstream's binaries are built with Go 1.26.5, so the stdlib wave, go-git 5.19.1 and two new x/mod advisories remain; clearing those would need a source rebuild, tracked separately.

Verification was done on the develop-branch build (#1173): the rebuilt image reports zot v2.1.20 / distribution-spec 1.1.1, and the rescan confirms the cleared and remaining findings above. The 2.1.19/2.1.20 changelogs carry no configuration-shape changes, so the zot 2.x config written by session-manager is unaffected.