### PR TITLE
fix(base-environment): upgrade the bundled npm to the 11.19 line

### DIFF
--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -103,6 +103,13 @@ RUN HOME=/root && \
     chown 1001:0 /opt && \
     ln -s /var/run/docker/docker.sock /var/run/docker.sock
 
+# Node 24 bundles an npm whose vendored tar lags the security fixes;
+# newer Node lines already bundle npm 11.19+, which carries the fixed
+# tar. Take the newest npm 11.x so rebuilds keep absorbing 11.x fixes.
+RUN npm install -g npm@11 && \
+    npm --version && \
+    rm -rf /root/.npm
+
 FROM system-base AS vscode-helper
 
 COPY opt/helper /opt/helper


### PR DESCRIPTION
Clears the last remaining CRITICAL finding in the images: `CVE-2026-59873` in the tar vendored inside npm's own node_modules.

Node 24 LTS still bundles npm 11.17.0 with tar 7.5.16 (fix threshold 7.5.19). npm 11.19.0 — the version newer Node release lines already bundle — ships tar 7.5.19, plus newer undici (6.27.0) and brace-expansion (5.0.7) copies. This adds an `npm install -g npm@11` layer after the Node install, floating the minor exactly as the unpinned `setup_24.x` Node install does, so rebuilds keep absorbing 11.x fixes automatically. Staying on the 11.x major means no behaviour change for workshop users (npm 12 was evaluated and rejected: it bundles the same tar 7.5.19, so the major jump buys no additional fix).

Verified by rebuild and rescan: the image reports npm 11.19.0 with bundled tar 7.5.19, and **the rebuilt base-environment image contains zero CRITICAL findings** — for the first time. Cleared alongside the CRITICAL: `CVE-2026-59874` (tar), `CVE-2026-12151` (undici), `CVE-2026-13149` (brace-expansion). Remaining in npm's tree (all awaiting future npm releases, no release anywhere ships the fixes yet): `CVE-2026-73566` (tar, fixed 7.5.21), `CVE-2026-14257`/`CVE-2026-69152` (brace-expansion), `CVE-2026-69192` (ip-address).

A matching PR against `release/3.8.0` carries the identical change (the system-base stage is identical on both branches).