### PR TITLE
fix(base-environment): upgrade the bundled npm to the 11.19 line

### DIFF
--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -103,6 +103,13 @@ RUN HOME=/root && \
     chown 1001:0 /opt && \
     ln -s /var/run/docker/docker.sock /var/run/docker.sock
 
+# Node 24 bundles an npm whose vendored tar lags the security fixes;
+# newer Node lines already bundle npm 11.19+, which carries the fixed
+# tar. Take the newest npm 11.x so rebuilds keep absorbing 11.x fixes.
+RUN npm install -g npm@11 && \
+    npm --version && \
+    rm -rf /root/.npm
+
 FROM system-base AS vscode-helper
 
 COPY opt/helper /opt/helper


### PR DESCRIPTION
3.8-line counterpart of educates/educates-training-platform#1175 — byte-identical change (the system-base stage is identical on both branches).

Clears `CVE-2026-59873` (CRITICAL, tar vendored inside npm's node_modules) by installing the newest npm 11.x over the Node-bundled 11.17.0: npm 11.19.0 ships tar 7.5.19, the fix version, plus newer undici and brace-expansion copies. The minor floats, as the unpinned Node install itself does, so rebuilds keep absorbing 11.x fixes; staying on the 11.x major means no behaviour change for workshop users.

Verification was done on the develop-branch rebuild (#1175): npm 11.19.0 with bundled tar 7.5.19 in the image, zero CRITICAL findings anywhere in the rebuilt base-environment, and the expected npm-tree residuals (newer advisories no npm release fixes yet) unchanged.